### PR TITLE
Typo: Reference sfc but have sfg written

### DIFF
--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -508,7 +508,7 @@ st_geometrycollection(gemetrycollection_list)
 One `sfg` object contains only a single simple feature geometry. 
 A simple feature geometry column (`sfc`) is a list of `sfg` objects, which is additionally able to contain information about the coordinate reference system in use.
 For instance, to combine two simple features into one object with two features, we can use the `st_sfc()` function. 
-This is important since `sfg` represents the geometry column in **sf** data frames:
+This is important since `sfc` represents the geometry column in **sf** data frames:
 
 ```{r}
 # sfc POINT


### PR DESCRIPTION
I believe there is a typo -- you refer to an sfc object but have sfg written, based on my understanding thus far, sfc is the geometry column comprised of sfg objects.