### PR TITLE
Referred to incorrect object

### DIFF
--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -524,7 +524,7 @@ Equally, a geometry column of multilinestrings would result in an `sfc` object o
 ```{r}
 # sfc POLYGON
 polygon_list1 = list(rbind(c(1, 5), c(2, 2), c(4, 1), c(4, 4), c(1, 5)))
-polygon1 = st_polygon(polygon_list)
+polygon1 = st_polygon(polygon_list1)
 polygon_list2 = list(rbind(c(0, 2), c(1, 2), c(1, 3), c(0, 3), c(0, 2)))
 polygon2 = st_polygon(polygon_list2)
 st_sfc(polygon1, polygon2)


### PR DESCRIPTION
In line 527, tried to create a sfg polygon from a list created in section 2.1.5.2, but believe you meant to create from the polygon list immediately preceding the transformation. Just left off a 1.