### PR TITLE
Reproducibility: show install.packages code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ cycle.*
 tmap_style_previews
 urb_anim.gif
 09-us_pop.gif
+spDataLarge*

--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -24,17 +24,27 @@ We assume that you have an up-to-date version of R installed and that you are co
 <!-- This will make it easier to run this book's worked examples on your computer. -->
 
 After you've checked you R installation and brushed-up on your R skills where appropriate, the next step is to install and load the packages used in this chapter.
-Packages are installed with `install.packages("package_name")`.
-We will use the two packages that provide functions for handling spatial data, loaded with `library(package_name)` as follows:
+Packages are installed with the `install.packages()` function which can be used to get the prerequisites on your computer:^[
+Note that the final package is not on R's main package hosting repository, CRAN, meaning that the `repos` and `type` arguments must be set for it to install.
+In case the installation fails, for example if you do not have rights to install non CRAN packages on your organisation's computers, the data in **spDataLarge** can be loaded by running the script [`spData.R`](https://github.com/Robinlovelace/geocompr/blob/master/code/spData.R) from the `code` folder in the book's GitHub repo at [github.com/Robinlovelace/geocompr](https://github.com/Robinlovelace/geocompr).
+]
+
+```{r, eval=FALSE}
+install.packages("sf")
+install.packages("raster")
+install.packages("spData")
+install.packages("spDataLarge", repos = "https://nowosad.github.io/drat/",
+                 type = "source")
+```
+
+Packages are loaded with the `library()` function, which is used to load the two spatial data processing packages installed previously as follows:
 
 ```{r, message=FALSE}
 library(sf)          # classes and functions for vector data
 library(raster)      # classes and functions for raster data
 ```
 
-The chapter also relies on two data packages: **spData** and **spDataLarge**.
-Importantly, the **spDataLarge** package needs be installed with the following command: `install.packages("spDataLarge", repos = "https://nowosad.github.io/drat/", type = "source")`.
-
+The other packages that were installed contain data that will be used in the book:
 
 ```{r, results='hide'}
 library(spData)        # load geographic data

--- a/code/spData.R
+++ b/code/spData.R
@@ -1,0 +1,7 @@
+# Aim load data from spDataLarge if you cannot install the package
+if(!dir.exists("spDataLarge-master/")) {
+  download.file("https://github.com/Nowosad/spDataLarge/archive/master.zip", "spDataLarge.zip")
+  unzip("spDataLarge.zip")
+}
+files_rda = list.files("spDataLarge-master/data/", full.names = TRUE)
+sapply(files_rda, load, envir = .GlobalEnv)


### PR DESCRIPTION
Aimed at new users not used to installing packages. Also allows the book to be reproduced if spDataLarge cannot be installed - e.g. on managed computers.

Heads-up @jannes-m and @Nowosad happy with this? This is for a situation I'm teaching where users cannot install packages from outside CRAN. Also new users are often confused when 'library(sf)` fails. I think adding this explicit install packages code is a good plan in this 1st practical chapter.