### PR TITLE
Fix typo in tmap annotation

### DIFF
--- a/code/09-tmshape.R
+++ b/code/09-tmshape.R
@@ -2,12 +2,12 @@ library(tmap)
 library(spData)
 # Add fill layer to nz shape
 m1 = tm_shape(nz) + tm_fill() +
-  tm_layout(title = "tmap_shape(nz) +\n  tm_fill()", title.size = 0.7)
+  tm_layout(title = "tm_shape(nz) +\n  tm_fill()", title.size = 0.7)
 # Add border layer to nz shape
 m2 = tm_shape(nz) + tm_borders() +
-  tm_layout("tmap_shape(nz) +\n  tm_borders()", title.size = 0.7) 
+  tm_layout("tm_shape(nz) +\n  tm_borders()", title.size = 0.7) 
 # Add fill and border layers to nz shape
 m3 = tm_shape(nz) + tm_fill() + tm_borders() +
-  tm_layout("tmap_shape(nz) +\n  tm_fill() +\n  tm_borders()", title.size = 0.7)
+  tm_layout("tm_shape(nz) +\n  tm_fill() +\n  tm_borders()", title.size = 0.7)
 tmap_arrange(m1, m2, m3, nrow = 1)
 


### PR DESCRIPTION
The annotation for the first tmap plots say tmap_shape when the function call is tm_shape.