### PR TITLE
Fixed filtering to empty data frame

### DIFF
--- a/coffeeApp/app.R
+++ b/coffeeApp/app.R
@@ -1,4 +1,4 @@
-# Credit: build on the exmaple in https://rstudio.github.io/leaflet/shiny.html
+# Credit: build on the example in https://rstudio.github.io/leaflet/shiny.html
 library(sf)
 library(shiny)
 library(spData)
@@ -33,9 +33,8 @@ server = function(input, output, session) {
   # Reactive expression for the data subsetted to what the user selected
   filteredData = reactive({
     world_coffee$Production = world_coffee[[yr()]]
-    sel = world_coffee$Production >= input$range[1] &
-      world_coffee$Production <= input$range[2]
-    world_coffee[sel, ]
+    filter(world_coffee, Production >= input$range[1] &
+                         Production <= input$range[2])
   })
   
   output$map = renderLeaflet({


### PR DESCRIPTION
This example would crash when filteredData() returned an empty sf object/data frame (reproducible by setting the threshold to 3300 - 4000). Switching from base-r index slicing to dplyr's filter fixed the problem.