### PR TITLE
Links to PROJ4 resources not working (404 error)

### DIFF
--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -949,7 +949,7 @@ Values of $a$ and $rf$ used in a variety of ellipsoidal models can be seen be ex
 
 Ellipsoids are part of a wider component of CRSs: the *datum*.
 This contains information on what ellipsoid to use (with the `ellps` parameter in the proj4 CRS library) and the precise relationship between the Cartesian coordinates and location on the Earth's surface.
-These additional details are stored in the `towgs84` argument of  [proj4](http://proj4.org/parameters.html#towgs84-datum-transformation-to-wgs84) notation (see [proj4.org/parameters.html](http://proj4.org/parameters.html) for details).
+These additional details are stored in the `towgs84` argument of  [proj4](https://proj4.org/operations/conversions/latlon.html?highlight=towgs#cmdoption-arg-towgs84) notation (see [proj4.org/parameters.html](https://proj4.org/usage/projections.html) for details).
 These allow local variations in Earth's surface, e.g. due to large mountain ranges, to be accounted for in a local CRS.
 There are two types of datum --- local and geocentric.
 In a *local datum* such as `NAD83` the ellipsoidal surface is shifted to align with the surface at a particular location.


### PR DESCRIPTION
The links provided in line 952 do not currently open a document. I went to the PROJ4 site and tried to find the relevant reference page based on the original URL. These are pages, not HTML documents, so not sure the links I have included are the ones you seek. This section is so great, by the way. I've never read a better description of the datum and it's purpose.