### PR TITLE
Minor correction in equivalence of read_sf() and st_read()

### DIFF
--- a/07-read-write-plot.Rmd
+++ b/07-read-write-plot.Rmd
@@ -411,14 +411,14 @@ Instead of columns describing xy-coordinates, a single column can also contain t
 Well-known text (WKT), well-known binary (WKB), and the GeoJSON formats are examples of this.
 For instance, the `world_wkt.csv` file has a column named `WKT` representing polygons of the world's countries.
 We will again use the `options` parameter to indicate this.
-Here, we will use `read_sf()` which does exactly the same as `st_read()` except it does not print the driver name to the console and stores strings as characters instead of factors.
+Here, we will use `read_sf()`, the tidyverse-flavoured version of `st_read()`: strings are parsed as characters instead of factors and the resulting data frame is a [tibble](https://r4ds.had.co.nz/tibbles.html). The driver name is also not printed to the console.
 
 ```{r 07-read-write-plot-21, results='hide'}
 world_txt = system.file("misc/world_wkt.csv", package = "spData")
 world_wkt = read_sf(world_txt, options = "GEOM_POSSIBLE_NAMES=WKT")
 # the same as
 world_wkt = st_read(world_txt, options = "GEOM_POSSIBLE_NAMES=WKT", 
-                    quiet = TRUE, stringsAsFactors = FALSE)
+                    quiet = TRUE, stringsAsFactors = FALSE, as_tibble = TRUE)
 ```
 
 ```{block2 07-read-write-plot-22, type='rmdnote'}

--- a/07-read-write-plot.Rmd
+++ b/07-read-write-plot.Rmd
@@ -618,7 +618,7 @@ plot(world["lifeExp"])
 dev.off()
 ```
 
-Other available graphic devices include `pdf()`, `bmp()`, `jpeg()`, `png()`, and `tiff()`. 
+Other available graphic devices include `pdf()`, `bmp()`, `jpeg()`, and `tiff()`. 
 You can specify several properties of the output plot, including width, height and resolution.
 
 Additionally, several graphic packages provide their own functions to save a graphical output.


### PR DESCRIPTION
Another difference of read_sf() is that it produces a tibble