### PR TITLE
Remove double-space in code. Suggest minor code formatting

### DIFF
--- a/07-read-write-plot.Rmd
+++ b/07-read-write-plot.Rmd
@@ -627,9 +627,8 @@ You can save a `tmap` object to different graphic formats by specifying the obje
 
 ```{r 07-read-write-plot-37, eval=FALSE}
 library(tmap)
-tmap_obj = tm_shape(world) +
-  tm_polygons(col = "lifeExp")
-tmap_save(tm  = tmap_obj, filename = "lifeExp_tmap.png")
+tmap_obj = tm_shape(world) + tm_polygons(col = "lifeExp")
+tmap_save(tm = tmap_obj, filename = "lifeExp_tmap.png")
 ```
 
 <!-- Note about that the `plot` function do not create an object -->


### PR DESCRIPTION
Putting tm_polygons() aligned keep things below the recommended max length, is more readable and is more consistent with other areas in the book (e.g. in chapter 8)