### PR TITLE
update Dockerfile with QGIS3 installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,34 @@
 FROM rocker/geospatial
 RUN R -e "remotes::install_github('r-spatial/lwgeom')"
 RUN R -e "remotes::install_github('geocompr/geocompkg')"
+# install RQGIS3 from github
+RUN R -e "remotes::install_github('jannes-m/RQGIS3')"
+RUN apt-get update && \
+  # software-properties-common contains add-apt-repository needed for ubuntugis
+  # apt-get install -y gpg software-properties-common && \
+  apt-get install -y gpg && \
+  # install QGIS and dependencies
+  sh -c 'echo "deb http://qgis.org/debian-ltr stretch main" >> /etc/apt/sources.list' && \
+  sh -c 'echo "deb-src http://qgis.org/debian-ltr stretch main" >> /etc/apt/sources.list' && \
+  # installing ubuntugis-unstable did not work
+  # sh -c 'echo "deb http://qgis.org/ubuntugis-ltr xenial main" >> /etc/apt/sources.list' && \
+  # sh -c 'echo "deb-src http://qgis.org/ubuntugis-ltr xenial main" >> /etc/apt/sources.list' && \
+  # sh -c 'echo "deb http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu xenial main" >> /etc/apt/sources.list' && \
+  # add-apt-repository ppa:ubuntugis/ubuntugis-unstable && \
+  wget -O - https://qgis.org/downloads/qgis-2019.gpg.key | gpg --no-tty --import && \
+  gpg --export --armor --no-tty --yes 51F523511C7028C3 | apt-key add - && \
+  apt-get update && apt-get install -qqy --no-install-recommends --fix-missing \
+  python3-pip \
+  python3-setuptools \
+  python3-qgis \
+  qgis \
+  qgis-plugin-grass\
+  # install SAGA 2.3.1
+  saga \
+  # install libs needed for virtual display
+  vnc4server \
+  xvfb && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*  && \
+  # install virtual display for Python
+  pip3 install pyvirtualdisplay


### PR DESCRIPTION
Hey Robin,
I have just added the stuff to the Dockerfile that will also install the latest QGIS LTR release. This way we will be able to run also RQGIS3, rgrass7 and RSAGA from within our geocompr docker container.
Regarding your dream to open up the the docker container inside the geocompr project folder, I suggest the following:
  
```sh
cd ~/
# the gecompr repository into your home 
# git clone git@github.com:Robinlovelace/geocompr.git 
git clone https://github.com/Robinlovelace/geocompr.git 
# run rocker-docker geocompr docker container while mounting local geocompr folder
cd geocompr
# then start rocker docker geocompr
docker run -e PASSWORD=pass -p 8787:8787 -v $(pwd):/home/rstudio/geocompr robinlovelace/geocompr
```
Now clicking the .Rproj file will also make available the git pane in RStudio. Please note that working on the geocompr files will change them also on disk, not only within the docker container!

The following does not work as expected. It creates the folder `home/rstudio/geocompr` but it does not `cd` into it: `docker run -e PASSWORD=pass -p 8787:8787 -v $(pwd):/home/rstudio/geocompr/ --workdir="/home/rstudio/geocompr/" robinlovelace/geocompr`.
