### PR TITLE
Include quotes in table of style tags

### DIFF
--- a/08-mapping.Rmd
+++ b/08-mapping.Rmd
@@ -257,12 +257,12 @@ In addition to manually setting `breaks` **tmap** allows users to specify algori
 \index{tmap (package)!break styles}
 Here are six of the most useful break styles:
 
-- `style = pretty`, the default setting, rounds breaks into whole numbers where possible and spaces them evenly;
-- `style = equal` divides input values into bins of equal range and is appropriate for variables with a uniform distribution (not recommended for variables with a skewed distribution as the resulting map may end-up having little color diversity);
-- `style = quantile` ensures the same number of observations fall into each category (with the potential downside that bin ranges can vary widely);
-- `style = jenks` identifies groups of similar values in the data and maximizes the differences between categories;
-- `style = cont` (and `order`) present a large number of colors over continuous color fields and are particularly suited for continuous rasters (`order` can help visualize skewed distributions);
-- `style = cat` was designed to represent categorical values and assures that each category receives a unique color.
+- `style = "pretty"`, the default setting, rounds breaks into whole numbers where possible and spaces them evenly;
+- `style = "equal"` divides input values into bins of equal range and is appropriate for variables with a uniform distribution (not recommended for variables with a skewed distribution as the resulting map may end-up having little color diversity);
+- `style = "quantile"` ensures the same number of observations fall into each category (with the potential downside that bin ranges can vary widely);
+- `style = "jenks"` identifies groups of similar values in the data and maximizes the differences between categories;
+- `style = "cont"` (and `order`) present a large number of colors over continuous color fields and are particularly suited for continuous rasters (`order` can help visualize skewed distributions);
+- `style = "cat"` was designed to represent categorical values and assures that each category receives a unique color.
 
 ```{r break-styles, message=FALSE, fig.cap="Illustration of different binning methods set using the style argument in tmap.", , fig.scap="Illustration of different binning methods using tmap.", echo=FALSE}
 source("https://github.com/Robinlovelace/geocompr/raw/master/code/08-break-styles.R", print.eval = TRUE)

--- a/08-mapping.Rmd
+++ b/08-mapping.Rmd
@@ -261,7 +261,7 @@ Here are six of the most useful break styles:
 - `style = "equal"` divides input values into bins of equal range and is appropriate for variables with a uniform distribution (not recommended for variables with a skewed distribution as the resulting map may end-up having little color diversity);
 - `style = "quantile"` ensures the same number of observations fall into each category (with the potential downside that bin ranges can vary widely);
 - `style = "jenks"` identifies groups of similar values in the data and maximizes the differences between categories;
-- `style = "cont"` (and `order`) present a large number of colors over continuous color fields and are particularly suited for continuous rasters (`order` can help visualize skewed distributions);
+- `style = "cont"` (and `"order"`) present a large number of colors over continuous color fields and are particularly suited for continuous rasters (`"order"` can help visualize skewed distributions);
 - `style = "cat"` was designed to represent categorical values and assures that each category receives a unique color.
 
 ```{r break-styles, message=FALSE, fig.cap="Illustration of different binning methods set using the style argument in tmap.", , fig.scap="Illustration of different binning methods using tmap.", echo=FALSE}


### PR DESCRIPTION
When actually writing the `style` code you need quote marks in the attribute, so i.e. `style = cont` won't work, but `style = "cont"` will. I suggest adding the quote marks to the entries in the table.