### PR TITLE
Resolve blank "raster" map in figure 5.25

### DIFF
--- a/code/05-raster-vectorization2.R
+++ b/code/05-raster-vectorization2.R
@@ -4,7 +4,7 @@ tmap_options(main.title.size = 1)
 
 cols = c("clay" = "brown", "sand" = "rosybrown", "silt" = "sandybrown")
 
-p1p = tm_shape(grain) + tm_raster(legend.show = FALSE, palette = cols) +
+p1p = tm_shape(as(grain, "SpatialGridDataFrame")) + tm_raster(legend.show = FALSE, palette = cols) +
   tm_layout(main.title = "Raster", frame = FALSE)
 
 if(!exists("grain_poly")) {


### PR DESCRIPTION
Currently, the "Raster" map in figure 5.25 is blank. The `grain` object needs to be converted to `SpatialGridDataFrame` in order to plot them correctly.

<img width="793" alt="figure525-blank" src="https://user-images.githubusercontent.com/29334677/79602478-1d126180-811d-11ea-811e-5b88f0ce84b4.png">

Sorry if I did anything wrong since this is my first pull request. :/
