### PR TITLE
load purrr for set_names()

### DIFF
--- a/03-attribute-operations.Rmd
+++ b/03-attribute-operations.Rmd
@@ -10,6 +10,7 @@ library(raster)
 library(dplyr)
 library(stringr) # for working with strings (pattern matching)
 library(tidyr)   # for unite() and separate()
+library(purrr)   # for set_names()
 ```
 
 - It also relies on **spData**, which loads datasets used in the code examples of this chapter:


### PR DESCRIPTION
set_names() used in 3.2.4 probably refers to function from purrr and needs to be loaded first