### PR TITLE
Fix typos in section 10.4: Functions

### DIFF
--- a/10-algorithms.Rmd
+++ b/10-algorithms.Rmd
@@ -339,8 +339,9 @@ Note that the functions we created are called iteratively in `lapply()`\index{lo
 ]
 
 ```{r 10-algorithms-15}
-poly_centroid = function(x) {
-  i = 2:(nrow(x) - 2)
+poly_centroid = function(poly_mat) {
+  Origin = poly_mat[1, ] # create a point representing the origin
+  i = 2:(nrow(poly_mat) - 2)
   T_all = lapply(i, function(x) {
     rbind(Origin, poly_mat[x:(x + 1), ], Origin)
   })
@@ -354,8 +355,9 @@ poly_centroid = function(x) {
 
 ```{r 10-algorithms-16, echo=FALSE, eval=FALSE}
 # a slightly more complex version of the function with output set
-poly_centroid = function(x, output = "matrix") {
-  i = 2:(nrow(x) - 2)
+poly_centroid = function(poly_mat, output = "matrix") {
+  Origin = poly_mat[1, ] # create a point representing the origin
+  i = 2:(nrow(poly_mat) - 2)
   T_all = T_all = lapply(i, function(x) {
     rbind(Origin, poly_mat[x:(x + 1), ], Origin)
   })


### PR DESCRIPTION
This PR fixes two small issues in the "Functions" section:
- The function's argument was given the name `x`, which both broke later references to `poly_mat` and shadowed an inner function's argument.
- The line defining `Origin` was missing.