### PR TITLE
Remove recommendation to DataCamp's 'Introduction to R'

### DIFF
--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -10,7 +10,7 @@ We assume that you have an up-to-date version of R installed and that you are co
 If you are new to R, we recommend reading Chapter 2 of the online book *Efficient R Programming* by @gillespie_efficient_2016 and
 <!-- , particularly sections 2.3 and 2.5, for details on R installation and set-up. -->
 <!-- [set-up](https://csgillespie.github.io/efficientR/set-up.html). -->
-learning the basics of the language with reference to resources such as @grolemund_r_2016 or [DataCamp](https://www.datacamp.com/courses/free-introduction-to-r) before proceeding.
+learning the basics of the language with reference to resources such as @grolemund_r_2016.
 Organize your work (e.g., with RStudio projects) and give scripts sensible names such as `chapter-02.R` to document the code you write as you learn.
 <!-- '[project](https://csgillespie.github.io/efficientR/set-up.html#project-management)' called `geocomp-learning`. -->
 <!--     Creating new script for each chapter or section of interest will help consolidate and extend the skills learned. -->

--- a/index.Rmd
+++ b/index.Rmd
@@ -198,7 +198,6 @@ However, we recommend reading about the wider context of *Geocomputation with R*
 If you are new to R, we also recommend learning more about the language before attempting to run the code chunks provided in each chapter (unless you're reading the book for an understanding of the concepts).
 Fortunately for R beginners R has a supportive community that has developed a wealth of resources that can help.
 We particularly recommend three tutorials:  [R for Data Science](http://r4ds.had.co.nz/) [@grolemund_r_2016] and [Efficient R Programming](https://csgillespie.github.io/efficientR/) [@gillespie_efficient_2016], especially [Chapter 2](https://csgillespie.github.io/efficientR/set-up.html#r-version) (on installing and setting-up R/RStudio) and [Chapter 10](https://csgillespie.github.io/efficientR/learning.html) (on learning to learn), and  [An introduction to R](http://colinfay.me/intro-to-r/) [@venables_introduction_2017].
-A good interactive tutorial is DataCamp's [Introduction to R](https://www.datacamp.com/courses/free-introduction-to-r).
 <!-- and tutorials created with [**learnr**](https://rstudio.github.io/learnr/examples.html). -->
 
 ## Why R? {-}


### PR DESCRIPTION
Would you consider removing the recommendation to DataCamp's [Introduction to R](https://www.datacamp.com/courses/free-introduction-to-r) course, written by [its former CEO](https://www.businessinsider.fr/us/datacamp-ceo-jonathan-cornelissen-leave-sexual-misconduct-allegation-2019-4)? The book already makes reference to two other excellent and free resources (*Efficient R programming* and *R for Data Science*).

P.S: Thank you for the book! I am really enjoying it.