### PR TITLE
geocompr.bib: attempt to add URL of r-spatial.org/book

### DIFF
--- a/geocompr.bib
+++ b/geocompr.bib
@@ -1320,7 +1320,8 @@
 @book{pebesma_spatial_2022,
   title = {Spatial {{Data Science}} with Applications in {{R}}},
   author = {Pebesma, Edzer and Bivand, Roger},
-  year = {2022}
+  year = {2022},
+  url = {https://r-spatial.org/book},
 }
 
 @book{perpinan_rastervis_2016,


### PR DESCRIPTION
I'm not sure whether this will actually result in the URL appearing in the bibliography; should depend on the applied citation style.

What follows are two sidenotes :wink: . Feel free to make them into issues, or whatever!

1.

Is the citation style actually set for HTML? From the Pandoc manual, it seems that `biblio-style` (currently in `index.Rmd` YAML header) is for LaTeX only:

> biblio-style
        bibliography style, when used with --natbib and --biblatex

For HTML, one could use the `csl` YAML key.

2.

Apart from that, CSL-JSON (`*.json`) or CSL-YAML (`*.yaml`) formats are actually better suited for storing bibliographic data when using Pandoc itself (not natbib) for producing citations & bibliography. It then uses its own CSL processor, pandoc-citeproc, which AFAIK is always used in case of HTML, and will by default be used for all formats including PDF. CSL-JSON / CSL-YAML are the preferred formats to use with pandoc-citeproc (with CSL-JSON being the official format for CSL, CSL-YAML is a one-to-one Pandoc-only converted format which is more human-readable/editable than json). Some more background in https://github.com/inbo/tutorials/issues/207#issuecomment-726869149.

BibTeX (`*.bib`) is supported by pandoc-citeproc, but the processing is necessarily [lossy](https://retorque.re/zotero-better-bibtex/exporting/pandoc/#use-csl-not-bibtex-with-pandoc) because the BibTeX format is less standardized than CSL-JSON.

One way to create json/yaml from another file format, is by using RStudio in VME mode. Or by using pandoc-citeproc on the command line (file conversion). Probably there are ways to do it from the R console as well, perhaps with `rbbt` or `rmarkdown` (didn't check).