### PR TITLE
Replace mentions of raster with terra where appropriate

### DIFF
--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -71,7 +71,7 @@ There is much overlap in some fields and raster and vector datasets can be used 
 ecologists and demographers, for example, commonly use both vector and raster data.
 Furthermore, it is possible to convert between the two forms (see Section \@ref(raster-vector)).
 Whether your work involves more use of vector or raster datasets, it is worth understanding the underlying data model before using them, as discussed in subsequent chapters.
-This book uses **sf** and **raster** packages to work with vector data and raster datasets, respectively.
+This book uses **sf** and **terra** packages to work with vector data and raster datasets, respectively.
 
 ## Vector data
 

--- a/04-spatial-operations.Rmd
+++ b/04-spatial-operations.Rmd
@@ -45,7 +45,7 @@ It is important to note that spatial operations that use two spatial objects rel
 
 ## Spatial operations on vector data {#spatial-vec}
 
-This section provides an overview of spatial operations on vector geographic data represented as simple features in the **sf** package before Section \@ref(spatial-ras), which presents spatial methods using the **raster** package.
+This section provides an overview of spatial operations on vector geographic data represented as simple features in the **sf** package before Section \@ref(spatial-ras), which presents spatial methods using the **terra** package.
 
 ### Spatial subsetting
 


### PR DESCRIPTION
I noticed two incorrect mentions of the `raster` package instead of `terra`. Both of these refer to the contents of the book, and I believe they are just typos. This pull request fixes them. I also checked for all mentions of `**raster**` in the first seven chapters using `grep` and read through the context to ensure the rest are correct.