### PR TITLE
Update data retrieval from spDataLarge

### DIFF
--- a/_04-ex.Rmd
+++ b/_04-ex.Rmd
@@ -43,13 +43,13 @@ nz_height_combined %>%
   na.omit()
 ```
 
-E4. Use `dem = rast(system.file("raster/dem.tif", package = "spDataLarge"))`, and reclassify the elevation in three classes: low (<300), medium and high (>500).
-Secondly, read the NDVI raster (`ndvi = rast(system.file("raster/ndvi.tif", package = "spDataLarge"))`) and compute the mean NDVI and the mean elevation for each altitudinal class.
+E4. Use `dem = rast(spDataLarge::dem)`, and reclassify the elevation in three classes: low (<300), medium and high (>500).
+Secondly, read the NDVI raster (`ndvi = rast(spDataLarge::ndvi)`) and compute the mean NDVI and the mean elevation for each altitudinal class.
 
 ```{r}
 library(terra)
-dem = rast(system.file("raster/dem.tif", package = "spDataLarge"))
-ndvi = rast(system.file("raster/ndvi.tif", package = "spDataLarge"))
+dem = rast(spDataLarge::dem)
+ndvi = rast(spDataLarge::ndvi)
 
 #1
 dem_rcl = matrix(c(-Inf, 300, 0, 300, 500, 1, 500, Inf, 2), ncol = 3, byrow = TRUE)


### PR DESCRIPTION
E4 in C4 uses two rasters that come with `spDataLarge`. To fetch them, the exercise suggests to use the files that come with the package. However, the NDVI file does not exist at the location the description points to.

``` r
ndvi = terra::rast(system.file("raster/ndvi.tif", package = "spDataLarge"))
#> Error: [rast] filename is empty. Provide a valid filename
system.file("raster/ndvi.tif", package = "spDataLarge")
#> [1] ""
```

Here are all the files I have in that folder:

```
dem.tif         landsat.tif     nlcd.tif        nlcd2011.tif    nz_elev.tif     srtm.tif
```

I found that the best way to access both of the files is directly through `spDataLarge` like `spDataLarge::dem` and `spDataLarge::ndvi`. The new version executes without problems:

``` r
library(terra)
#> terra version 1.4.20
dem = rast(spDataLarge::dem)
ndvi = rast(spDataLarge::ndvi)

#1
dem_rcl = matrix(c(-Inf, 300, 0, 300, 500, 1, 500, Inf, 2), ncol = 3, byrow = TRUE)
dem_reclass = classify(dem, dem_rcl)
levels(dem_reclass) = c("low", "medium", "high")
plot(dem_reclass)
```

![](https://i.imgur.com/sKjimGP.png)

``` r
#2
zonal(c(dem, ndvi), dem_reclass, fun = "mean")
#>      dem      dem       ndvi
#> 1    low 274.3910 -0.3631755
#> 2 medium 392.0486 -0.2893352
#> 3   high 765.2197 -0.2075496
```