### PR TITLE
Fix typos in C7, clarify a sentence in C8

### DIFF
--- a/07-read-write-plot.Rmd
+++ b/07-read-write-plot.Rmd
@@ -47,13 +47,13 @@ Various 'geoportals' (web services providing geospatial datasets such as [Data.g
 \index{geoportals}
 Some global geoportals overcome this issue.
 The [GEOSS portal](http://www.geoportal.org/) and the [Copernicus Open Access Hub](https://scihub.copernicus.eu/), for example, contain many raster datasets with global coverage.
-A wealth of vector datasets can be accessed from the National Aeronautics and Space Administration agency (NASA), [SEDAC](http://sedac.ciesin.columbia.edu/) portal and the European Union's [INSPIRE geoportal](http://inspire-geoportal.ec.europa.eu/), with global and regional coverage.
+A wealth of vector datasets can be accessed from the National Aeronautics and Space Administration agency's (NASA) [SEDAC](http://sedac.ciesin.columbia.edu/) portal and the European Union's [INSPIRE geoportal](http://inspire-geoportal.ec.europa.eu/), with global and regional coverage.
 
 Most geoportals provide a graphical interface allowing datasets to be queried based on characteristics such as spatial and temporal extent, the United States Geological Services' [EarthExplorer](https://earthexplorer.usgs.gov/) being a prime example.
 *Exploring* datasets interactively on a browser is an effective way of understanding available layers.
 *Downloading* data is best done with code, however, from reproducibility and efficiency perspectives.
 Downloads can be initiated from the command line using a variety of techniques, primarily via URLs and APIs\index{API} (see the [Sentinel API](https://scihub.copernicus.eu/twiki/do/view/SciHubWebPortal/APIHubDescription) for example).
-Files hosted on static URLs can be downloaded with `download.file()`, as illustrated in the code chunk below which accesses US National Parks data from: [catalog.data.gov/dataset/national-parks](https://catalog.data.gov/dataset/national-parks):
+Files hosted on static URLs can be downloaded with `download.file()`, as illustrated in the code chunk below which accesses US National Parks data from [catalog.data.gov/dataset/national-parks](https://catalog.data.gov/dataset/national-parks):
 
 ```{r 07-read-write-plot-2, eval=FALSE}
 download.file(url = "http://nrdata.nps.gov/programs/lands/nps_boundary.zip",

--- a/08-mapping.Rmd
+++ b/08-mapping.Rmd
@@ -175,7 +175,8 @@ Of course, these default values and other aesthetics can be overridden.
 The purpose of this section is to show how.
 
 There are two main types of map aesthetics: those that change with the data and those that are constant.
-Unlike **ggplot2**, which uses the helper function `aes()` to represent variable aesthetics, **tmap** accepts aesthetic arguments that are either variable fields (based on column names) or constant values.^[
+Unlike **ggplot2**, which uses the helper function `aes()` to represent variable aesthetics, **tmap** accepts aesthetic arguments directly.
+To map a variable to an aesthetic, pass its column name to the corresponding argument, and to set a fixed aesthetic, pass the desired value instead.^[
 If there is a clash between a fixed value and a column name, the column name takes precedence. This can be verified by running the next code chunk after running `nz$red = 1:nrow(nz)`.
 ]
 The most commonly used aesthetics for fill and border layers include color, transparency, line width and line type, set with `col`, `alpha`, `lwd`, and `lty` arguments, respectively.

--- a/_07-ex.Rmd
+++ b/_07-ex.Rmd
@@ -3,7 +3,7 @@ E1. List and describe three types of vector, raster, and geodatabase formats.
 
 E2. Name at least two differences between `read_sf()` and the more well-known function `st_read()`.
 
-E3. Read the `cycle_hire_xy.csv` file from the **spData** package as a spatial object (Hint: it is located in the `misc\` folder).
+E3. Read the `cycle_hire_xy.csv` file from the **spData** package as a spatial object (Hint: it is located in the `misc` folder).
 What is a geometry type of the loaded object? 
 
 E4. Download the borders of Germany using **rnaturalearth**, and create a new object called `germany_borders`.


### PR DESCRIPTION
The changes to chapter 7 are simple typos.

The change in chapter 8 is my attempt to make the sentence more clear. It seems like the sentence started as a comparison of `ggplot2` and `tmap` in terms of variable aesthetics but then ended up just specifying what arguments `tmap` accepts. I feel like splitting these ideas makes sense.