### PR TITLE
Fix for issue - https://github.com/Robinlovelace/geocompr/issues/740

### DIFF
--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -734,7 +734,8 @@ The **terra** package supports raster objects in R.
 Like its predecessor **raster** (created by the same developer, Robert Hijmans), it provides an extensive set of functions to create, read, export, manipulate and process raster datasets.
 **terra**'s functionality is largely the same as the more mature **raster** package, but there are some differences: **terra** functions are usually more computationally efficient than **raster** equivalents.
 <!-- todo: add evidence (RL 2021-11) -->
-On the other hand, the **raster** class system is popular and used by many other packages; as with **sf** and **sp**, the good news is you can seamlessly translate between the two types of object to ensure backwards compatibility with older scripts and packages, for example, with the functions `raster::raster()`, `raster::stack()`, or `raster::brick()` (see the previous chapter for more on the evolution of R packages for working with geographic data).
+On the other hand, the **raster** class system is popular and used by many other packages.
+You can seamlessly translate between the two types of object to ensure backwards compatibility with older scripts and packages, for example, with the functions [`raster()`](https://rspatial.github.io/raster/reference/raster.html), [`stack()`](https://rspatial.github.io/raster/reference/stack.html), and `brick()` in the **raster** package (see the previous chapter for more on the evolution of R packages for working with geographic data).
 
 ```{r, echo=FALSE, eval=FALSE}
 # # test raster/terra conversions

--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -734,7 +734,7 @@ The **terra** package supports raster objects in R.
 Like its predecessor **raster** (created by the same developer, Robert Hijmans), it provides an extensive set of functions to create, read, export, manipulate and process raster datasets.
 **terra**'s functionality is largely the same as the more mature **raster** package, but there are some differences: **terra** functions are usually more computationally efficient than **raster** equivalents.
 <!-- todo: add evidence (RL 2021-11) -->
-On the other hand, the **raster** class system is popular and used by many other packages; as with **sf** and **sp**, the good news is you can seamlessly translate between the two types of object to ensure backwards compatibility with older scripts and packages, for example, with the functions `raster()`, `stack()`, or `brick()` (see the previous chapter for more on the evolution of R packages for working with geographic data).
+On the other hand, the **raster** class system is popular and used by many other packages; as with **sf** and **sp**, the good news is you can seamlessly translate between the two types of object to ensure backwards compatibility with older scripts and packages, for example, with the functions `raster::raster()`, `raster::stack()`, or `raster::brick()` (see the previous chapter for more on the evolution of R packages for working with geographic data).
 
 ```{r, echo=FALSE, eval=FALSE}
 # # test raster/terra conversions


### PR DESCRIPTION
The 3 functions were not loaded, since raster library was not loaded. Prefixing these with `raster::` tells bookdown to link to the documentation for these functions.

If I find more of these I'll flag them as this Issue.