### PR TITLE
selecting layers with name

### DIFF
--- a/02-spatial-data.Rmd
+++ b/02-spatial-data.Rmd
@@ -999,7 +999,7 @@ It accepts a layer number or its name as the second argument:
 
 ```{r}
 multi_rast3 = subset(multi_rast, 3)
-multi_rast4 = subset(multi_rast, 4)
+multi_rast4 = subset(multi_rast, "lan_4")
 ```
 
 The opposite operation, combining several `SpatRaster` objects into one, can be done using the `c` function:


### PR DESCRIPTION
adapting code to show the second part of 

> It accepts a layer number or its name as the second argument:

https://github.com/Robinlovelace/geocompr/blob/7fe62c8e7f465a228f3e2e7782e3519c41cd86da/02-spatial-data.Rmd#L998

Not a game changer!