### PR TITLE
footnote starting line 114

### DIFF
--- a/07-reproj.Rmd
+++ b/07-reproj.Rmd
@@ -114,6 +114,7 @@ WKT strings are exhaustive, detailed, and precise, allowing for unambiguous CRSs
 They contain all relevant information about any given CRS, including its datum and ellipsoid, prime meridian, projection, and units.^[
 Before the emergence of WKT CRS definitions, proj-string was the standard way to specify coordinate operations and store CRSs.
 These string representations, built on a key=value form (e.g, `+proj=longlat +datum=WGS84 +no_defs`), have already been, or should in the future be, superseded by WKT representations in most cases.
+]
 
 Recent PROJ versions (6+) still allow use of proj-strings to define coordinate operations, but some proj-string keys (`+nadgrids`, `+towgs84`, `+k`, `+init=epsg:`) are either no longer supported or are discouraged.
 <!-- ref? (RL 2022-06) -->
@@ -121,7 +122,6 @@ Recent PROJ versions (6+) still allow use of proj-strings to define coordinate o
 <!-- only three datums (i.e., WGS84, NAD83, and NAD27) can be directly set in proj-string. -->
 Longer explanations of the evolution of CRS definitions and the PROJ library can be found in @bivand_progress_2021, Chapter 2 of @pebesma_spatial_2022, and [blog post by Floris Vanderhaeghe](https://inbo.github.io/tutorials/tutorials/spatial_crs_coding/).
 As outlined in the [PROJ documentation](https://proj.org/development/reference/cpp/cpp_general.html) there are different versions of the WKT CRS format including WKT1 and two variants of WKT2, the latter of which (WKT2, 2018 specification) corresponds to the ISO 19111:2019 [@opengeospatialconsortium_wellknown_2019].
-]
 
 ## Querying and setting coordinate systems {#crs-setting}
 


### PR DESCRIPTION
The footnote starting at line 114 ends at line 124, containing two paragraphs.

This is currently the footnote 27 in https://geocompr.robinlovelace.net/reproj-geo-data.html#crs-in-r . However the second paragraph does not  appear in the foot note.

Reading the footnote, the footnote is supposed to be just the first part. So, `]` should be in line 117?