### PR TITLE
Fixes in beginning of ch 8

### DIFF
--- a/08-read-write-plot.Rmd
+++ b/08-read-write-plot.Rmd
@@ -58,8 +58,9 @@ Downloads can be initiated from the command line using a variety of techniques, 
 Files hosted on static URLs can be downloaded with `download.file()`, as illustrated in the code chunk below which accesses US National Parks data from [catalog.data.gov/dataset/national-parks](https://catalog.data.gov/dataset/national-parks):
 
 ```{r 07-read-write-plot-2, eval=FALSE}
-download.file(url = "https://irma.nps.gov/DataStore/DownloadFile/666527",
-              destfile = "nps_boundary.zip")
+download.file(url = "https://irma.nps.gov/DataStore/DownloadFile/673366",
+              destfile = "nps_boundary.zip",
+              mode = "wb")
 unzip(zipfile = "nps_boundary.zip")
 usa_parks = read_sf(dsn = "nps_boundary.shp")
 ```


### PR DESCRIPTION
See #833. I don't have a Mac VM or linux installation readibly available but would be good to see if `mode = "wb"` in `download.file()` impacts unix based systems.