### PR TITLE
Removing remaining resolution argument

### DIFF
--- a/03-attribute-operations.Rmd
+++ b/03-attribute-operations.Rmd
@@ -652,7 +652,7 @@ The following code creates the raster datasets shown in Figure \@ref(fig:cont-ra
 grain_order = c("clay", "silt", "sand")
 grain_char = sample(grain_order, 36, replace = TRUE)
 grain_fact = factor(grain_char, levels = grain_order)
-grain = rast(nrows = 6, ncols = 6, resolution = 0.5, 
+grain = rast(nrows = 6, ncols = 6, 
              xmin = -1.5, xmax = 1.5, ymin = -1.5, ymax = 1.5,
              vals = grain_fact)
 ```


### PR DESCRIPTION
Removing the resolution argument from the code block defining the categorical raster, to keep it consistent with decision in the code block defining elev raster.