### PR TITLE
Enhance elevation profile accuracy with cumulative path distance

### DIFF
--- a/06-raster-vector.Rmd
+++ b/06-raster-vector.Rmd
@@ -240,15 +240,14 @@ print(plot_transect, vp = viewport(layout.pos.row = 2, layout.pos.col = 2))
 The previous method calculates straight-line distances from the starting point, which may not reflect the actual length of curved or winding paths. To compute true distances along a non-linear route, the coordinates of the segmented points can be used to calculate cumulative distances between successive points:
 
 ```r
-zion_transect_coordinates <- zion_transect |> group_by(id) |> st_coordinates()
-point_distances <- c(
+zion_transect_coordinates = zion_transect |> group_by(id) |> st_coordinates()
+point_distances = c(
   0, 
   cumsum(sqrt(rowSums(diff(zion_transect_coordinates)^2)))
 )
-zion_transect <- zion_transect |> 
+zion_transect = zion_transect |> 
   mutate(dist = point_distances)
 ```
-
 This approach sums the Euclidean distance between each pair of consecutive points along the path, yielding a more realistic elevation profile for non-linear transects.
 
 \index{raster!extraction polygons} 


### PR DESCRIPTION
This commit adds an improved method for computing cumulative distances along a non-linear path when extracting elevation profiles from rasters. It replaces the straight-line (Euclidean) distance calculation with a stepwise sum of distances between consecutive points, ensuring more accurate results for curved transects. The new code enhances real-world applicability, especially for hiking trails and routes with turns or elevation changes.

**Original Code from the Book**: This computes the straight-line (Euclidean) distance from the first point to every other point using `st_distance()`. This works well only if the transect path is a straight line.
```r
zion_transect <- zion_transect |> 
  group_by(id) |> 
  mutate(dist = st_distance(geometry)[, 1])
```
**Proposed Improved Code**: This code accounts for the real path distance, even when the route is not a straight line.
```r
# This extracts coordinates of all points along the transect,
# grouped by ID to support multiple transects if present.

zion_transect_coordinates <- zion_transect |>  
  group_by(id) |>  
  st_coordinates()

# Calculates the cumulative distance along the actual (curved) path
# by computing Euclidean distance between each pair of consecutive points.

point_distances <- c(  
  0,   
  cumsum(sqrt(rowSums(diff(zion_transect_coordinates)^2)))  
)

# Adds the computed cumulative distances back to the main spatial object.

zion_transect <- zion_transect |>  
  mutate(dist = point_distances)
```