### PR TITLE
Update 05-geometry-operations.Rmd ("Note:" appears twice)

### DIFF
--- a/05-geometry-operations.Rmd
+++ b/05-geometry-operations.Rmd
@@ -610,7 +610,7 @@ knitr::kable(sfs_st_cast,
                              "output type by column."),
              caption.short = "Geometry casting on simple feature geometries.",
              booktabs = TRUE) |> 
-  kableExtra::add_footnote("Note: Values in parentheses represent the number of features; NA means the operation is not available", notation = "none")
+  kableExtra::add_footnote("Values in parentheses represent the number of features; NA means the operation is not available", notation = "none")
 ```
 
 Let's try to apply geometry type transformations on a new object, `multilinestring_sf`, as an example (on the left in Figure \@ref(fig:line-cast)):


### PR DESCRIPTION
add_footnote() includes the word "Note:" so there is no need to write it.  it currently appears twice.